### PR TITLE
chore: ignore macOS DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .zmk/
 
 firmware/
+
+.DS_Store


### PR DESCRIPTION
## Summary
- Ignore macOS .DS_Store metadata files in this repo

## Test plan
- Verified git diff only changes .gitignore