### PR TITLE
refactor: split shared ZMK aliases from layer definitions

### DIFF
--- a/config/bdn9_rev2.keymap
+++ b/config/bdn9_rev2.keymap
@@ -19,7 +19,6 @@
 #define SPOTIFY 1
 #define SYSCTL  2
 
-#define PV_NT_TOD HPR(N7)
 
 / {
 	macros {

--- a/config/bdn9_rev2.keymap
+++ b/config/bdn9_rev2.keymap
@@ -4,7 +4,7 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/rgb.h>
 
-#include "pvinis_shared.dtsi"
+#include "pvinis_keys.dtsi"
 
 &sensors {
 	status = "okay";
@@ -19,16 +19,7 @@
 #define SPOTIFY 1
 #define SYSCTL  2
 
-#define PV_SP_PLAYPAUSE HPR(N1)
-#define PV_SP_NEXT      HPR(N2)
-#define PV_SP_PREV      HPR(N3)
-#define PV_SP_MUTE      HPR(N4)
-#define PV_SP_VOLD      HPR(N5)
-#define PV_SP_VOLU      HPR(N6)
-#define PV_NT_TOD       HPR(N7)
-#define PV_RORO         HPR(N8)
-#define PV_SCRSVR       HPR(N9)
-#define PV_SLEEP   LA(LG(C_POWER))
+#define PV_NT_TOD HPR(N7)
 
 / {
 	macros {

--- a/config/pvinis_keys.dtsi
+++ b/config/pvinis_keys.dtsi
@@ -11,6 +11,7 @@
 #define PV_SP_MUTE      HPR(N4)
 #define PV_SP_VOLD      HPR(N5)
 #define PV_SP_VOLU      HPR(N6)
+#define PV_NT_TOD       HPR(N7)
 #define PV_RORO         HPR(N8)
 #define PV_SCRSVR       HPR(N9)
 #define PV_SLEEP        LA(LG(C_POWER))

--- a/config/pvinis_keys.dtsi
+++ b/config/pvinis_keys.dtsi
@@ -1,11 +1,4 @@
-// layers
-#define QWERTY 0
-#define SYSCTL 1
-#define SYMBOL 2
-#define NUMBER 3
-#define KBCTL  4
-
-// keys
+// shared key aliases
 #define ______ &trans
 
 #define HYPER    LS(LC(LA(LGUI)))
@@ -18,9 +11,7 @@
 #define PV_SP_MUTE      HPR(N4)
 #define PV_SP_VOLD      HPR(N5)
 #define PV_SP_VOLU      HPR(N6)
-// #define PV_NT_TOD       HPR(N7)
 #define PV_RORO         HPR(N8)
 #define PV_SCRSVR       HPR(N9)
-// #define PV_SLEEP   LA(LG(C_POWER))
+#define PV_SLEEP        LA(LG(C_POWER))
 #define PV_VOICE        HPR(V)
-

--- a/config/pvinis_split_layers.dtsi
+++ b/config/pvinis_split_layers.dtsi
@@ -1,0 +1,6 @@
+// shared split keyboard layers
+#define QWERTY 0
+#define SYSCTL 1
+#define SYMBOL 2
+#define NUMBER 3
+#define KBCTL  4

--- a/config/sofle.keymap
+++ b/config/sofle.keymap
@@ -5,12 +5,7 @@
 #include <dt-bindings/zmk/ext_power.h>
 
 #include "pvinis_keys.dtsi"
-
-#define QWERTY 0
-#define SYSCTL 1
-#define SYMBOL 2
-#define NUMBER 3
-#define KBCTL  4
+#include "pvinis_split_layers.dtsi"
 
 / {
 	// activate KBCTL layer by pressing SYSCTL and SYMBOL

--- a/config/sofle.keymap
+++ b/config/sofle.keymap
@@ -4,7 +4,13 @@
 #include <dt-bindings/zmk/rgb.h>
 #include <dt-bindings/zmk/ext_power.h>
 
-#include "pvinis_shared.dtsi"
+#include "pvinis_keys.dtsi"
+
+#define QWERTY 0
+#define SYSCTL 1
+#define SYMBOL 2
+#define NUMBER 3
+#define KBCTL  4
 
 / {
 	// activate KBCTL layer by pressing SYSCTL and SYMBOL

--- a/config/splitkb_aurora_corne.keymap
+++ b/config/splitkb_aurora_corne.keymap
@@ -4,12 +4,7 @@
 #include <dt-bindings/zmk/outputs.h>
 
 #include "pvinis_keys.dtsi"
-
-#define QWERTY 0
-#define SYSCTL 1
-#define SYMBOL 2
-#define NUMBER 3
-#define KBCTL  4
+#include "pvinis_split_layers.dtsi"
 
 / {
 	// tap dance

--- a/config/splitkb_aurora_corne.keymap
+++ b/config/splitkb_aurora_corne.keymap
@@ -3,7 +3,13 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
 
-#include "pvinis_shared.dtsi"
+#include "pvinis_keys.dtsi"
+
+#define QWERTY 0
+#define SYSCTL 1
+#define SYMBOL 2
+#define NUMBER 3
+#define KBCTL  4
 
 / {
 	// tap dance


### PR DESCRIPTION
## Summary
- Move reusable key aliases into config/pvinis_keys.dtsi
- Define layer IDs locally in the board keymaps that use them
- Remove the obsolete config/pvinis_shared.dtsi file
- Remove duplicated shared aliases from the BDN9 keymap

## Test plan
- Parsed YAML files successfully
- Checked for stale pvinis_shared.dtsi includes
- Reviewed git diff to confirm key bindings are preserved